### PR TITLE
netlify.toml 수정: Next.js 정적 내보내기를 위한 URL 리다이렉트 규칙 제거 및 정적 파일 직접 제공으로 …

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -48,23 +48,12 @@
   [headers.values]
     Content-Type = "application/xml"
 
-# URL rewrite rules for Next.js static export with Korean URL support
-[[redirects]]
-  from = "/posts/*"
-  to = "/posts/:splat/index.html"
-  status = 200
-  conditions = {Role = ["visitor"]}
-
-# Handle trailing slash for posts
-[[redirects]]
-  from = "/posts/*/index.html"
-  to = "/posts/:splat/"
-  status = 301
+# Next.js static export - direct file serving (no rewrites needed)
+# Static files are served directly by Netlify
 
 # SPA fallback for client-side routing (only if file doesn't exist)
 [[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
-  conditions = {Role = ["visitor"]}
   force = false


### PR DESCRIPTION
…변경. 클라이언트 사이드 라우팅을 위한 SPA 폴백 유지.